### PR TITLE
the great header refactor

### DIFF
--- a/small_paino/renderer.cpp
+++ b/small_paino/renderer.cpp
@@ -38,10 +38,10 @@ void draw_rect(float x, float y, float half_size_x, float half_size_y, unsigned 
     x += render_state.width / 2.f;
     y += render_state.height / 2.f;
 
-    int x0 = x - half_size_x;
-    int x1 = x + half_size_x;
-    int y0 = y - half_size_y;
-    int y1 = y + half_size_y;
+    int x0 = (int) (x - half_size_x);
+    int x1 = (int) (x + half_size_x);
+    int y0 = (int) (y - half_size_y);
+    int y1 = (int) (y + half_size_y);
 
     draw_rect_in_pixels(x0, y0, x1, y1, color);
 }

--- a/small_paino/renderer.cpp
+++ b/small_paino/renderer.cpp
@@ -24,7 +24,7 @@ draw_rect_in_pixels(int x0, int y0, int x1, int y1, unsigned int color) {
     }
 }
 
-global_variable float render_scale = 0.01f
+global_variable float render_scale = 0.01f;
 
 internal void
 draw_rect(float x, float y, float half_size_x, float half_size_y, unsigned int color) {

--- a/small_paino/renderer.cpp
+++ b/small_paino/renderer.cpp
@@ -1,5 +1,10 @@
-internal void 
-clear_screen(unsigned int color){
+#include <algorithm>
+#include "renderer.h"
+// make it constant, meaning a true-constant
+// maybe rechange it to global_variable later
+constexpr float render_scale = 0.01f;
+
+void clear_screen(unsigned int color){
     unsigned int* pixel = (unsigned int*)render_state.memory;
     for (int y = 0; y < render_state.height; y++) {
         for (int x = 0; x < render_state.width; x++) {
@@ -8,13 +13,12 @@ clear_screen(unsigned int color){
     }
 }
 
-internal void
-draw_rect_in_pixels(int x0, int y0, int x1, int y1, unsigned int color) {
+void draw_rect_in_pixels(int x0, int y0, int x1, int y1, unsigned int color) {
 
-    x0 = clamp(0, x0, render_state.width);
-    x1 = clamp(0, x1, render_state.width);
-    y0 = clamp(0, y0, render_state.height);
-    y1 = clamp(0, y1, render_state.height);
+    x0 = std::clamp(0, x0, render_state.width);
+    x1 = std::clamp(0, x1, render_state.width);
+    y0 = std::clamp(0, y0, render_state.height);
+    y1 = std::clamp(0, y1, render_state.height);
 
     for (int y = y0; y < y1; y++) {
         unsigned int* pixel = (unsigned int*)render_state.memory + x0 + y * render_state.width;
@@ -24,10 +28,7 @@ draw_rect_in_pixels(int x0, int y0, int x1, int y1, unsigned int color) {
     }
 }
 
-global_variable float render_scale = 0.01f;
-
-internal void
-draw_rect(float x, float y, float half_size_x, float half_size_y, unsigned int color) {
+void draw_rect(float x, float y, float half_size_x, float half_size_y, unsigned int color) {
 
     x *= render_state.width * render_scale;
     y *= render_state.height * render_scale;

--- a/small_paino/renderer.h
+++ b/small_paino/renderer.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "Windows.h"
+
+struct Render_State {
+    int height, width;
+    void* memory;
+    BITMAPINFO bitmap_info;
+};
+// declare the global variable so that other files may access it
+// since it's cross-file variable don't add global_variable prefix
+extern Render_State render_state;
+
+void clear_screen(unsigned int color);
+void draw_rect_in_pixels(int x0, int y0, int x1, int y1, unsigned int color);
+void draw_rect(float x, float y, float half_size_x, float half_size_y, unsigned int color);

--- a/small_paino/small_paino.vcxproj
+++ b/small_paino/small_paino.vcxproj
@@ -76,6 +76,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -90,6 +91,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -104,6 +106,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -118,6 +121,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -127,19 +131,12 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="renderer.cpp">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="utiles.cpp">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-    </ClCompile>
+    <ClCompile Include="renderer.cpp" />
     <ClCompile Include="win32_platform.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="renderer.h" />
+    <ClInclude Include="utiles.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/small_paino/small_paino.vcxproj.filters
+++ b/small_paino/small_paino.vcxproj.filters
@@ -21,8 +21,13 @@
     <ClCompile Include="renderer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="utiles.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="renderer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="utiles.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/small_paino/utiles.cpp
+++ b/small_paino/utiles.cpp
@@ -1,9 +1,0 @@
-inline int
-clamp(int min, int val, int max) {
-    if (val < min) return min;
-    if (val > max) return max;
-    return val;
-}
-
-#define global_variable static
-#define internal static

--- a/small_paino/utiles.h
+++ b/small_paino/utiles.h
@@ -1,0 +1,2 @@
+#define global_variable static
+#define internal static

--- a/small_paino/win32_platform.cpp
+++ b/small_paino/win32_platform.cpp
@@ -59,7 +59,7 @@ int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int n
         }
 
         clear_screen(0xff5500);
-        draw_rect(0, 0, 0.1, 0.2, 0xff0000);
+        draw_rect(0, 0, 0.1f, 0.2f, 0xff0000);
 
         StretchDIBits(hdc, 0, 0, render_state.width, render_state.height, 0, 0, render_state.width, render_state.height, render_state.memory, &render_state.bitmap_info, DIB_RGB_COLORS, SRCCOPY);
     }

--- a/small_paino/win32_platform.cpp
+++ b/small_paino/win32_platform.cpp
@@ -1,16 +1,9 @@
 #include <Windows.h>
-#include "utiles.cpp"
+#include "utiles.h"
+#include "renderer.h"
 
 global_variable bool running = true;
-
-struct Render_State {
-    int height, width;
-    void* memory;
-    BITMAPINFO bitmap_info;
-};
-
-global_variable Render_State render_state;
-#include "renderer.cpp"
+Render_State render_state;
 
 LRESULT CALLBACK window_callback(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
     LRESULT result = 0;


### PR DESCRIPTION
so, all function declaration are in a seperate header file.
the render_state variable is a global cross-file variable, therfor it cannot use the global_variable macro.
I didn't touch any of the code itself at all.